### PR TITLE
Support running in browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,9 @@
-const isWin = process.platform === 'win32';
+let isWin;
+try {
+    isWin = process.platform === 'win32';
+} catch (err) {
+    isWin = false
+}
 const SEP = isWin ? `\\\\+` : `\\/`;
 const SEP_ESC = isWin ? `\\\\` : `/`;
 const GLOBSTAR = `((?:[^/]*(?:/|$))*)`;


### PR DESCRIPTION
I'm using globrex as a dependency of https://github.com/wheresrhys/fetch-mock. To avoid users having to configure their builds to stub out `process`, I'm submitting this PR to gracefully handle the absence of `process`